### PR TITLE
feat: improve keydb write latencies

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,367 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/rudderlabs/keydb/proto"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+)
+
+// mockNodeServiceServer implements the NodeServiceServer interface for testing
+type mockNodeServiceServer struct {
+	proto.UnimplementedNodeServiceServer
+	getFunc           func(context.Context, *proto.GetRequest) (*proto.GetResponse, error)
+	putFunc           func(context.Context, *proto.PutRequest) (*proto.PutResponse, error)
+	getNodeInfoFunc   func(context.Context, *proto.GetNodeInfoRequest) (*proto.GetNodeInfoResponse, error)
+	scaleFunc         func(context.Context, *proto.ScaleRequest) (*proto.ScaleResponse, error)
+	scaleCompleteFunc func(context.Context, *proto.ScaleCompleteRequest) (*proto.ScaleCompleteResponse, error)
+	createSnapFunc    func(context.Context, *proto.CreateSnapshotsRequest) (*proto.CreateSnapshotsResponse, error)
+	loadSnapFunc      func(context.Context, *proto.LoadSnapshotsRequest) (*proto.LoadSnapshotsResponse, error)
+	clusterSize       uint32
+	nodesAddresses    []string
+}
+
+func (m *mockNodeServiceServer) Get(ctx context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, req)
+	}
+
+	// Default implementation
+	exists := make([]bool, len(req.Keys))
+	for i := range req.Keys {
+		exists[i] = true // Default to all keys existing
+	}
+
+	return &proto.GetResponse{
+		Exists:         exists,
+		ErrorCode:      proto.ErrorCode_NO_ERROR,
+		ClusterSize:    m.clusterSize,
+		NodesAddresses: m.nodesAddresses,
+	}, nil
+}
+
+func (m *mockNodeServiceServer) Put(ctx context.Context, req *proto.PutRequest) (*proto.PutResponse, error) {
+	if m.putFunc != nil {
+		return m.putFunc(ctx, req)
+	}
+
+	// Default implementation
+	return &proto.PutResponse{
+		Success:        true,
+		ErrorCode:      proto.ErrorCode_NO_ERROR,
+		ClusterSize:    m.clusterSize,
+		NodesAddresses: m.nodesAddresses,
+	}, nil
+}
+
+func (m *mockNodeServiceServer) GetNodeInfo(ctx context.Context, req *proto.GetNodeInfoRequest) (*proto.GetNodeInfoResponse, error) {
+	if m.getNodeInfoFunc != nil {
+		return m.getNodeInfoFunc(ctx, req)
+	}
+
+	return &proto.GetNodeInfoResponse{}, nil
+}
+
+func (m *mockNodeServiceServer) Scale(ctx context.Context, req *proto.ScaleRequest) (*proto.ScaleResponse, error) {
+	if m.scaleFunc != nil {
+		return m.scaleFunc(ctx, req)
+	}
+
+	return &proto.ScaleResponse{Success: true}, nil
+}
+
+func (m *mockNodeServiceServer) ScaleComplete(ctx context.Context, req *proto.ScaleCompleteRequest) (*proto.ScaleCompleteResponse, error) {
+	if m.scaleCompleteFunc != nil {
+		return m.scaleCompleteFunc(ctx, req)
+	}
+
+	return &proto.ScaleCompleteResponse{Success: true}, nil
+}
+
+func (m *mockNodeServiceServer) CreateSnapshots(ctx context.Context, req *proto.CreateSnapshotsRequest) (*proto.CreateSnapshotsResponse, error) {
+	if m.createSnapFunc != nil {
+		return m.createSnapFunc(ctx, req)
+	}
+
+	return &proto.CreateSnapshotsResponse{Success: true}, nil
+}
+
+func (m *mockNodeServiceServer) LoadSnapshots(ctx context.Context, req *proto.LoadSnapshotsRequest) (*proto.LoadSnapshotsResponse, error) {
+	if m.loadSnapFunc != nil {
+		return m.loadSnapFunc(ctx, req)
+	}
+
+	return &proto.LoadSnapshotsResponse{Success: true}, nil
+}
+
+func startMockServer(t *testing.T, server *mockNodeServiceServer, address string) func() {
+	t.Helper()
+
+	// Create a TCP listener on the specified address.
+	lis, err := net.Listen("tcp", address)
+	require.NoError(t, err)
+
+	s := grpc.NewServer()
+	proto.RegisterNodeServiceServer(s, server)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			panic(fmt.Sprintf("Server exited with error: %v", err))
+		}
+	}()
+
+	return func() {
+		s.Stop()
+		lis.Close()
+	}
+}
+
+func createTestClientWithServers(t *testing.T, addresses []string) (*Client, func()) {
+	t.Helper()
+
+	// Create client with custom dialer for bufconn
+	client, err := NewClient(Config{
+		Addresses:       addresses,
+		TotalHashRanges: 128,
+		RetryCount:      1,
+		RetryDelay:      time.Millisecond,
+	}, logger.NOP, WithStats(stats.NOP))
+
+	require.NoError(t, err)
+
+	// Override connections with bufconn connections
+	client.mu.Lock()
+	for i := range client.connections {
+		_ = client.connections[i].Close()
+	}
+
+	for i, addr := range addresses {
+		conn, err := grpc.NewClient(addr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+
+		client.connections[i] = conn
+		client.clients[i] = proto.NewNodeServiceClient(conn)
+	}
+	client.mu.Unlock()
+
+	return client, func() {
+		_ = client.Close()
+	}
+}
+
+func createTestClient(t *testing.T, clusterSize uint32) (*Client, func()) {
+	t.Helper()
+
+	addresses := make([]string, clusterSize)
+	for i := range addresses {
+		httpPort, err := testhelper.GetFreePort()
+		require.NoError(t, err)
+		address := fmt.Sprintf(":%d", httpPort)
+		addresses[i] = address
+	}
+
+	// Create mock servers
+	servers := make([]*mockNodeServiceServer, clusterSize)
+	for i := range addresses {
+		servers[i] = &mockNodeServiceServer{
+			clusterSize:    clusterSize,
+			nodesAddresses: addresses,
+		}
+	}
+
+	// Start mock servers
+	closers := make([]func(), len(addresses))
+	for i, server := range servers {
+		closer := startMockServer(t, server, addresses[i])
+		closers[i] = closer
+	}
+
+	client, closer := createTestClientWithServers(t, addresses)
+
+	return client, func() {
+		_ = client.Close()
+		closer()
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	t.Run("successful get", func(t *testing.T) {
+		clusterSize := 3
+
+		client, closer := createTestClient(t, uint32(clusterSize))
+		defer closer()
+		keys := []string{"key1", "key2", "key3"}
+
+		exists, err := client.Get(context.Background(), keys)
+		require.NoError(t, err)
+		require.Len(t, exists, len(keys))
+		for _, e := range exists {
+			require.True(t, e)
+		}
+	})
+
+	t.Run("get with error", func(t *testing.T) {
+		httpPort, err := testhelper.GetFreePort()
+		require.NoError(t, err)
+		address := fmt.Sprintf(":%d", httpPort)
+		// Create a client with a server that returns an error
+		errorServer := &mockNodeServiceServer{
+			getFunc: func(ctx context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
+				return nil, fmt.Errorf("simulated error")
+			},
+			clusterSize:    1,
+			nodesAddresses: []string{address},
+		}
+
+		closer := startMockServer(t, errorServer, address)
+		defer closer()
+
+		errorClient, closer := createTestClientWithServers(t, []string{address})
+		defer closer()
+
+		keys := []string{"key1"}
+		_, err = errorClient.Get(context.Background(), keys)
+		require.Error(t, err)
+	})
+
+	t.Run("some true some false", func(t *testing.T) {
+		reqResp := map[string]bool{
+			"key1": true,
+			"key2": false,
+			"key3": true,
+			"key4": false,
+			"key5": true,
+			"key6": false,
+		}
+
+		httpPort1, err := testhelper.GetFreePort()
+		require.NoError(t, err)
+		address1 := fmt.Sprintf(":%d", httpPort1)
+		httpPort2, err := testhelper.GetFreePort()
+		require.NoError(t, err)
+		address2 := fmt.Sprintf(":%d", httpPort2)
+		httpPort3, err := testhelper.GetFreePort()
+		require.NoError(t, err)
+		address3 := fmt.Sprintf(":%d", httpPort3)
+		// Create a client with a server that returns an error
+		server1 := &mockNodeServiceServer{
+			getFunc: func(ctx context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
+				exists := make([]bool, len(req.Keys))
+				for i := range req.Keys {
+					exists[i] = reqResp[req.Keys[i]]
+				}
+				return &proto.GetResponse{
+					Exists:         exists,
+					ErrorCode:      proto.ErrorCode_NO_ERROR,
+					ClusterSize:    3,
+					NodesAddresses: []string{address1, address2, address3},
+				}, nil
+			},
+			clusterSize:    3,
+			nodesAddresses: []string{address1, address2, address3},
+		}
+		server2 := &mockNodeServiceServer{
+			getFunc: func(ctx context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
+				exists := make([]bool, len(req.Keys))
+				for i := range req.Keys {
+					exists[i] = reqResp[req.Keys[i]]
+				}
+				return &proto.GetResponse{
+					Exists:         exists,
+					ErrorCode:      proto.ErrorCode_NO_ERROR,
+					ClusterSize:    3,
+					NodesAddresses: []string{address1, address2, address3},
+				}, nil
+			},
+			clusterSize:    3,
+			nodesAddresses: []string{address1, address2, address3},
+		}
+		server3 := &mockNodeServiceServer{
+			getFunc: func(ctx context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
+				exists := make([]bool, len(req.Keys))
+				for i := range req.Keys {
+					exists[i] = reqResp[req.Keys[i]]
+				}
+				return &proto.GetResponse{
+					Exists:         exists,
+					ErrorCode:      proto.ErrorCode_NO_ERROR,
+					ClusterSize:    3,
+					NodesAddresses: []string{address1, address2, address3},
+				}, nil
+			},
+			clusterSize:    3,
+			nodesAddresses: []string{address1, address2, address3},
+		}
+
+		closer := startMockServer(t, server1, address1)
+		defer closer()
+
+		closer = startMockServer(t, server2, address2)
+		defer closer()
+
+		closer = startMockServer(t, server3, address3)
+		defer closer()
+
+		client, closer := createTestClientWithServers(t, []string{address1, address2, address3})
+		defer closer()
+
+		keys := []string{"key1", "key2", "key3", "key4", "key5", "key6"}
+		exists, err := client.Get(context.Background(), keys)
+		require.NoError(t, err)
+		require.Len(t, exists, len(keys))
+		for i, e := range exists {
+			require.Equal(t, reqResp[keys[i]], e)
+		}
+	})
+}
+
+func TestClient_Put(t *testing.T) {
+	t.Run("successful put", func(t *testing.T) {
+		client, closer := createTestClient(t, 3)
+		defer closer()
+		keys := []string{"key1", "key2", "key3"}
+		ttl := time.Hour
+
+		err := client.Put(context.Background(), keys, ttl)
+		require.NoError(t, err)
+	})
+
+	t.Run("put with error", func(t *testing.T) {
+		httpPort, err := testhelper.GetFreePort()
+		require.NoError(t, err)
+		address := fmt.Sprintf(":%d", httpPort)
+		addresses := []string{address}
+
+		// Create a client with a server that returns an error
+		errorServer := &mockNodeServiceServer{
+			putFunc: func(ctx context.Context, req *proto.PutRequest) (*proto.PutResponse, error) {
+				return nil, fmt.Errorf("simulated error")
+			},
+			clusterSize:    uint32(len(addresses)),
+			nodesAddresses: addresses,
+		}
+
+		closer := startMockServer(t, errorServer, address)
+		defer closer()
+
+		errorClient, closer := createTestClientWithServers(t, []string{address})
+		defer closer()
+
+		keys := []string{"key1"}
+		err = errorClient.Put(context.Background(), keys, time.Hour)
+		require.Error(t, err)
+	})
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -65,7 +65,9 @@ func (m *mockNodeServiceServer) Put(ctx context.Context, req *proto.PutRequest) 
 	}, nil
 }
 
-func (m *mockNodeServiceServer) GetNodeInfo(ctx context.Context, req *proto.GetNodeInfoRequest) (*proto.GetNodeInfoResponse, error) {
+func (m *mockNodeServiceServer) GetNodeInfo(ctx context.Context, req *proto.GetNodeInfoRequest) (
+	*proto.GetNodeInfoResponse, error,
+) {
 	if m.getNodeInfoFunc != nil {
 		return m.getNodeInfoFunc(ctx, req)
 	}
@@ -81,7 +83,9 @@ func (m *mockNodeServiceServer) Scale(ctx context.Context, req *proto.ScaleReque
 	return &proto.ScaleResponse{Success: true}, nil
 }
 
-func (m *mockNodeServiceServer) ScaleComplete(ctx context.Context, req *proto.ScaleCompleteRequest) (*proto.ScaleCompleteResponse, error) {
+func (m *mockNodeServiceServer) ScaleComplete(ctx context.Context, req *proto.ScaleCompleteRequest) (
+	*proto.ScaleCompleteResponse, error,
+) {
 	if m.scaleCompleteFunc != nil {
 		return m.scaleCompleteFunc(ctx, req)
 	}
@@ -89,7 +93,9 @@ func (m *mockNodeServiceServer) ScaleComplete(ctx context.Context, req *proto.Sc
 	return &proto.ScaleCompleteResponse{Success: true}, nil
 }
 
-func (m *mockNodeServiceServer) CreateSnapshots(ctx context.Context, req *proto.CreateSnapshotsRequest) (*proto.CreateSnapshotsResponse, error) {
+func (m *mockNodeServiceServer) CreateSnapshots(ctx context.Context, req *proto.CreateSnapshotsRequest) (
+	*proto.CreateSnapshotsResponse, error,
+) {
 	if m.createSnapFunc != nil {
 		return m.createSnapFunc(ctx, req)
 	}
@@ -97,7 +103,9 @@ func (m *mockNodeServiceServer) CreateSnapshots(ctx context.Context, req *proto.
 	return &proto.CreateSnapshotsResponse{Success: true}, nil
 }
 
-func (m *mockNodeServiceServer) LoadSnapshots(ctx context.Context, req *proto.LoadSnapshotsRequest) (*proto.LoadSnapshotsResponse, error) {
+func (m *mockNodeServiceServer) LoadSnapshots(ctx context.Context, req *proto.LoadSnapshotsRequest) (
+	*proto.LoadSnapshotsResponse, error,
+) {
 	if m.loadSnapFunc != nil {
 		return m.loadSnapFunc(ctx, req)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -190,15 +190,10 @@ func TestClient_Put(t *testing.T) {
 // mockNodeServiceServer implements the NodeServiceServer interface for testing
 type mockNodeServiceServer struct {
 	proto.UnimplementedNodeServiceServer
-	getFunc           func(context.Context, *proto.GetRequest) (*proto.GetResponse, error)
-	putFunc           func(context.Context, *proto.PutRequest) (*proto.PutResponse, error)
-	getNodeInfoFunc   func(context.Context, *proto.GetNodeInfoRequest) (*proto.GetNodeInfoResponse, error)
-	scaleFunc         func(context.Context, *proto.ScaleRequest) (*proto.ScaleResponse, error)
-	scaleCompleteFunc func(context.Context, *proto.ScaleCompleteRequest) (*proto.ScaleCompleteResponse, error)
-	createSnapFunc    func(context.Context, *proto.CreateSnapshotsRequest) (*proto.CreateSnapshotsResponse, error)
-	loadSnapFunc      func(context.Context, *proto.LoadSnapshotsRequest) (*proto.LoadSnapshotsResponse, error)
-	clusterSize       uint32
-	nodesAddresses    []string
+	getFunc        func(context.Context, *proto.GetRequest) (*proto.GetResponse, error)
+	putFunc        func(context.Context, *proto.PutRequest) (*proto.PutResponse, error)
+	clusterSize    uint32
+	nodesAddresses []string
 }
 
 func (m *mockNodeServiceServer) Get(ctx context.Context, req *proto.GetRequest) (*proto.GetResponse, error) {
@@ -237,48 +232,28 @@ func (m *mockNodeServiceServer) Put(ctx context.Context, req *proto.PutRequest) 
 func (m *mockNodeServiceServer) GetNodeInfo(ctx context.Context, req *proto.GetNodeInfoRequest) (
 	*proto.GetNodeInfoResponse, error,
 ) {
-	if m.getNodeInfoFunc != nil {
-		return m.getNodeInfoFunc(ctx, req)
-	}
-
 	return &proto.GetNodeInfoResponse{}, nil
 }
 
 func (m *mockNodeServiceServer) Scale(ctx context.Context, req *proto.ScaleRequest) (*proto.ScaleResponse, error) {
-	if m.scaleFunc != nil {
-		return m.scaleFunc(ctx, req)
-	}
-
 	return &proto.ScaleResponse{Success: true}, nil
 }
 
 func (m *mockNodeServiceServer) ScaleComplete(ctx context.Context, req *proto.ScaleCompleteRequest) (
 	*proto.ScaleCompleteResponse, error,
 ) {
-	if m.scaleCompleteFunc != nil {
-		return m.scaleCompleteFunc(ctx, req)
-	}
-
 	return &proto.ScaleCompleteResponse{Success: true}, nil
 }
 
 func (m *mockNodeServiceServer) CreateSnapshots(ctx context.Context, req *proto.CreateSnapshotsRequest) (
 	*proto.CreateSnapshotsResponse, error,
 ) {
-	if m.createSnapFunc != nil {
-		return m.createSnapFunc(ctx, req)
-	}
-
 	return &proto.CreateSnapshotsResponse{Success: true}, nil
 }
 
 func (m *mockNodeServiceServer) LoadSnapshots(ctx context.Context, req *proto.LoadSnapshotsRequest) (
 	*proto.LoadSnapshotsResponse, error,
 ) {
-	if m.loadSnapFunc != nil {
-		return m.loadSnapFunc(ctx, req)
-	}
-
 	return &proto.LoadSnapshotsResponse{Success: true}, nil
 }
 

--- a/cmd/node/config.go
+++ b/cmd/node/config.go
@@ -23,15 +23,15 @@ var customBuckets = map[string][]float64{
 		0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20,
 	},
 	"keydb_keys_hashing_duration_seconds": {
-		// 1microsecond, 2.5microsecond, 5microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
-		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
+		// 1 micro, 5 micro, 10 micro, 50 micro, 100 micro, 500 micro, 1ms, 5ms, 10ms
+		0.000001, 0.000005, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01,
 	},
 	"keydb_grpc_cache_get_duration_seconds": {
 		// 10microsecond, 25microsecond, 50microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
 		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
 	},
 	"keydb_grpc_cache_put_duration_seconds": {
-		// 1microsecond, 5microsecond, 10microsecond, 50microsecond, 100microsecond, 200microsecond
-		0.000001, 0.000005, 0.00001, 0.00005, 0.0001, 0.0002,
+		// 10microsecond, 25microsecond, 50microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
+		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
 	},
 }

--- a/cmd/node/config.go
+++ b/cmd/node/config.go
@@ -27,11 +27,11 @@ var customBuckets = map[string][]float64{
 		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
 	},
 	"keydb_grpc_cache_get_duration_seconds": {
-		// 1microsecond, 2.5microsecond, 5microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
+		// 10microsecond, 25microsecond, 50microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
 		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
 	},
 	"keydb_grpc_cache_put_duration_seconds": {
-		// 1microsecond, 2.5microsecond, 5microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
-		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
+		// 1microsecond, 5microsecond, 10microsecond, 50microsecond, 100microsecond, 200microsecond
+		0.000001, 0.000005, 0.00001, 0.00005, 0.0001, 0.0002,
 	},
 }

--- a/cmd/node/config.go
+++ b/cmd/node/config.go
@@ -22,4 +22,16 @@ var customBuckets = map[string][]float64{
 		// 1ms, 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 20s
 		0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20,
 	},
+	"keydb_keys_hashing_duration_seconds": {
+		// 1microsecond, 2.5microsecond, 5microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
+		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
+	},
+	"keydb_grpc_cache_get_duration_seconds": {
+		// 1microsecond, 2.5microsecond, 5microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
+		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
+	},
+	"keydb_grpc_cache_put_duration_seconds": {
+		// 1microsecond, 2.5microsecond, 5microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
+		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
+	},
 }

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"regexp"
@@ -70,8 +72,11 @@ func main() {
 	}
 
 	if err := run(ctx, cancel, conf, stat, log); err != nil {
-		log.Fataln("Failed to run", obskit.Error(err))
-		os.Exit(1)
+		if !errors.Is(err, context.Canceled) {
+			log.Errorn("Failed to run", obskit.Error(err))
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 }
 
@@ -188,10 +193,21 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 		}
 	}()
 
-	// Start the server
-	if err := server.Serve(lis); err != nil {
-		return fmt.Errorf("failed to serve: %w", err)
-	}
+	serverErrCh := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrCh <- fmt.Errorf("server error: %w", err)
+		}
+	}()
 
-	return ctx.Err()
+	select {
+	case <-ctx.Done():
+		log.Infon("Shutting down HTTP server")
+		server.GracefulStop()
+		return ctx.Err()
+	case err := <-serverErrCh:
+		return err
+	}
 }

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -206,6 +206,10 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 	case <-ctx.Done():
 		log.Infon("Shutting down HTTP server")
 		server.GracefulStop()
+		err := lis.Close()
+		if err != nil {
+			return err
+		}
 		return ctx.Err()
 	case err := <-serverErrCh:
 		return err

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -146,7 +146,8 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 		case <-doneCh:
 			return
 		case <-time.After(conf.GetDuration("shutdownTimeout", 15, time.Second)):
-			log.Errorn("graceful termination failed", logger.NewDurationField("timeoutAfter", time.Since(shutdownStarted)))
+			log.Errorn("graceful termination failed",
+				logger.NewDurationField("timeoutAfter", time.Since(shutdownStarted)))
 			fmt.Print("\n\n")
 			_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 			fmt.Print("\n\n")

--- a/internal/cache/badger/badger.go
+++ b/internal/cache/badger/badger.go
@@ -369,7 +369,6 @@ func (c *Cache) LoadSnapshots(ctx context.Context, readers ...io.Reader) error {
 }
 
 func (c *Cache) RunGarbageCollection() {
-	c.logger.Infon("levels before garbage collection", logger.NewStringField("levels", c.cache.LevelsToString()))
 again: // see https://dgraph.io/docs/badger/get-started/#garbage-collection
 	err := c.cache.RunValueLogGC(c.discardRatio)
 	if err == nil {

--- a/internal/cache/badger/badger.go
+++ b/internal/cache/badger/badger.go
@@ -128,11 +128,11 @@ func New(conf *config.Config, log logger.Logger) (*Cache, error) {
 }
 
 // Get returns the values associated with the keys and an error if the operation failed
-func (c *Cache) Get(itemsByHashRange map[uint32][]string, indexes map[string]int) ([]bool, error) {
+func (c *Cache) Get(keysByHashRange map[uint32][]string, indexes map[string]int) ([]bool, error) {
 	results := make([]bool, len(indexes))
 
 	err := c.cache.View(func(txn *badger.Txn) error {
-		for hashRange, keys := range itemsByHashRange {
+		for hashRange, keys := range keysByHashRange {
 			for _, key := range keys {
 				_, err := txn.Get(c.getKey(key, hashRange))
 				if err != nil {
@@ -156,11 +156,11 @@ func (c *Cache) Get(itemsByHashRange map[uint32][]string, indexes map[string]int
 }
 
 // Put adds or updates elements inside the cache with the specified TTL and returns an error if the operation failed
-func (c *Cache) Put(itemsByHashRange map[uint32][]string, ttl time.Duration) error {
+func (c *Cache) Put(keysByHashRange map[uint32][]string, ttl time.Duration) error {
 	modifiedTTL := c.getTTL(ttl)
 
 	bw := c.cache.NewWriteBatch()
-	for hashRange, keys := range itemsByHashRange {
+	for hashRange, keys := range keysByHashRange {
 		for _, key := range keys {
 			cacheKey := c.getKey(key, hashRange)
 			entry := badger.NewEntry(cacheKey, nil)

--- a/internal/cache/badger/badger.go
+++ b/internal/cache/badger/badger.go
@@ -369,6 +369,7 @@ func (c *Cache) LoadSnapshots(ctx context.Context, readers ...io.Reader) error {
 }
 
 func (c *Cache) RunGarbageCollection() {
+	c.logger.Infon("levels before garbage collection", logger.NewStringField("levels", c.cache.LevelsToString()))
 again: // see https://dgraph.io/docs/badger/get-started/#garbage-collection
 	err := c.cache.RunValueLogGC(c.discardRatio)
 	if err == nil {

--- a/internal/cache/badger/badger_test.go
+++ b/internal/cache/badger/badger_test.go
@@ -49,10 +49,10 @@ func TestSnapshots(t *testing.T) {
 			require.NoError(t, bdb.Close())
 		})
 
-		err = bdb.Put([]string{"key1", "key2"}, time.Hour, 0)
+		err = bdb.Put(map[uint32][]string{0: {"key1", "key2"}}, time.Hour)
 		require.NoError(t, err)
 
-		exists, err := bdb.Get([]string{"key1", "key2"}, 0)
+		exists, err := bdb.Get(map[uint32][]string{0: {"key1", "key2"}}, map[string]int{"key1": 0, "key2": 1})
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true}, exists)
 
@@ -73,9 +73,10 @@ func TestSnapshots(t *testing.T) {
 		require.Len(t, files, 1)
 		t.Logf("1st snapshot created: %+v", uploadedFile1)
 
-		err = bdb.Put([]string{"key3", "key4"}, time.Hour, 0)
+		err = bdb.Put(map[uint32][]string{0: {"key3", "key4"}}, time.Hour)
 		require.NoError(t, err)
-		exists, err = bdb.Get([]string{"key1", "key2", "key3", "key4"}, 0)
+		exists, err = bdb.Get(map[uint32][]string{0: {"key1", "key2", "key3", "key4"}},
+			map[string]int{"key1": 0, "key2": 1, "key3": 2, "key4": 3})
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true, true, true}, exists)
 
@@ -113,7 +114,8 @@ func TestSnapshots(t *testing.T) {
 		err = newBdb.LoadSnapshots(context.Background(), tmpFile)
 		require.NoError(t, err)
 
-		exists, err = newBdb.Get([]string{"key1", "key2", "key3", "key4"}, 0)
+		exists, err = newBdb.Get(map[uint32][]string{0: {"key1", "key2", "key3", "key4"}},
+			map[string]int{"key1": 0, "key2": 1, "key3": 2, "key4": 3})
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true, false, false}, exists)
 
@@ -127,7 +129,8 @@ func TestSnapshots(t *testing.T) {
 		err = newBdb.LoadSnapshots(context.Background(), tmpFile2)
 		require.NoError(t, err)
 
-		exists, err = newBdb.Get([]string{"key1", "key2", "key3", "key4"}, 0)
+		exists, err = newBdb.Get(map[uint32][]string{0: {"key1", "key2", "key3", "key4"}},
+			map[string]int{"key1": 0, "key2": 1, "key3": 2, "key4": 3})
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true, true, true}, exists)
 	}

--- a/internal/cache/badger/badger_test.go
+++ b/internal/cache/badger/badger_test.go
@@ -49,10 +49,10 @@ func TestSnapshots(t *testing.T) {
 			require.NoError(t, bdb.Close())
 		})
 
-		err = bdb.Put([]string{"key1", "key2"}, time.Hour)
+		err = bdb.Put([]string{"key1", "key2"}, time.Hour, 0)
 		require.NoError(t, err)
 
-		exists, err := bdb.Get([]string{"key1", "key2"})
+		exists, err := bdb.Get([]string{"key1", "key2"}, 0)
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true}, exists)
 
@@ -73,9 +73,9 @@ func TestSnapshots(t *testing.T) {
 		require.Len(t, files, 1)
 		t.Logf("1st snapshot created: %+v", uploadedFile1)
 
-		err = bdb.Put([]string{"key3", "key4"}, time.Hour)
+		err = bdb.Put([]string{"key3", "key4"}, time.Hour, 0)
 		require.NoError(t, err)
-		exists, err = bdb.Get([]string{"key1", "key2", "key3", "key4"})
+		exists, err = bdb.Get([]string{"key1", "key2", "key3", "key4"}, 0)
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true, true, true}, exists)
 
@@ -113,7 +113,7 @@ func TestSnapshots(t *testing.T) {
 		err = newBdb.LoadSnapshots(context.Background(), tmpFile)
 		require.NoError(t, err)
 
-		exists, err = newBdb.Get([]string{"key1", "key2", "key3", "key4"})
+		exists, err = newBdb.Get([]string{"key1", "key2", "key3", "key4"}, 0)
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true, false, false}, exists)
 
@@ -127,7 +127,7 @@ func TestSnapshots(t *testing.T) {
 		err = newBdb.LoadSnapshots(context.Background(), tmpFile2)
 		require.NoError(t, err)
 
-		exists, err = newBdb.Get([]string{"key1", "key2", "key3", "key4"})
+		exists, err = newBdb.Get([]string{"key1", "key2", "key3", "key4"}, 0)
 		require.NoError(t, err)
 		require.Equal(t, []bool{true, true, true, true}, exists)
 	}

--- a/internal/cache/badger/badger_test.go
+++ b/internal/cache/badger/badger_test.go
@@ -43,7 +43,7 @@ func TestSnapshots(t *testing.T) {
 		conf := config.New()
 		conf.Set("BadgerDB.Dedup.Compress", compress)
 		conf.Set("BadgerDB.Dedup.Path", t.TempDir())
-		bdb, err := New(&mockHasher{}, conf, logger.NOP)
+		bdb, err := New(conf, logger.NOP)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, bdb.Close())
@@ -97,7 +97,7 @@ func TestSnapshots(t *testing.T) {
 
 		// Load 1st snapshot into a new BadgerDB
 		conf.Set("BadgerDB.Dedup.Path", t.TempDir())
-		newBdb, err := New(&mockHasher{}, conf, logger.NOP)
+		newBdb, err := New(conf, logger.NOP)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			require.NoError(t, newBdb.Close())
@@ -254,29 +254,4 @@ func getCloudStorage(t testing.TB, pool *dockertest.Pool, conf *config.Config) (
 	require.NoError(t, err)
 
 	return minioClient, cloudStorage
-}
-
-type mockHasher struct{}
-
-func (m *mockHasher) GetKeysByHashRange(keys []string) (
-	map[uint32][]string, // itemsByHashRange
-	error,
-) {
-	mp := make(map[uint32][]string)
-	mp[0] = append(mp[0], keys...)
-	return mp, nil
-}
-
-func (m *mockHasher) GetKeysByHashRangeWithIndexes(keys []string) (
-	map[uint32][]string, // itemsByHashRange
-	map[string]int, // indexes
-	error,
-) {
-	mp := make(map[uint32][]string)
-	indexes := make(map[string]int, len(keys))
-	for i, key := range keys {
-		mp[0] = append(mp[0], key)
-		indexes[key] = i
-	}
-	return mp, indexes, nil
 }

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -38,7 +38,7 @@ func GetNodeNumber(key string, numberOfNodes, totalHashRanges uint32) (uint32, u
 }
 
 func GetKeysByHashRange(keys []string, nodeID, numberOfNodes, totalHashRanges uint32) (
-	map[uint32][]string, // itemsByHashRange
+	map[uint32][]string, // keysByHashRange
 	error,
 ) {
 	if numberOfNodes == 0 {
@@ -67,7 +67,7 @@ func GetKeysByHashRange(keys []string, nodeID, numberOfNodes, totalHashRanges ui
 }
 
 func GetKeysByHashRangeWithIndexes(keys []string, nodeID, numberOfNodes, totalHashRanges uint32) (
-	map[uint32][]string, // itemsByHashRange
+	map[uint32][]string, // keysByHashRange
 	map[string]int, // indexes
 	error,
 ) {

--- a/node/node.go
+++ b/node/node.go
@@ -190,10 +190,14 @@ func NewService(
 	service.metrics.getKeysCounters = make(map[uint32]stats.Counter)
 	service.metrics.putKeysCounter = make(map[uint32]stats.Counter)
 	service.metrics.gcDuration = stat.NewTaggedStat("keydb_gc_duration_seconds", stats.HistogramType, statsTags)
-	service.metrics.getKeysHashingDuration = stat.NewTaggedStat("keydb_keys_hashing_duration_seconds", stats.TimerType, stats.Tags{"method": "get"})
-	service.metrics.getFromCacheDuration = stat.NewTaggedStat("keydb_grpc_cache_get_duration_seconds", stats.TimerType, statsTags)
-	service.metrics.putKeysHashingDuration = stat.NewTaggedStat("keydb_keys_hashing_duration_seconds", stats.TimerType, stats.Tags{"method": "put"})
-	service.metrics.putFromCacheDuration = stat.NewTaggedStat("keydb_grpc_cache_put_duration_seconds", stats.TimerType, statsTags)
+	service.metrics.getKeysHashingDuration = stat.NewTaggedStat("keydb_keys_hashing_duration_seconds", stats.TimerType,
+		stats.Tags{"method": "get"})
+	service.metrics.getFromCacheDuration = stat.NewTaggedStat("keydb_grpc_cache_get_duration_seconds",
+		stats.TimerType, statsTags)
+	service.metrics.putKeysHashingDuration = stat.NewTaggedStat("keydb_keys_hashing_duration_seconds", stats.TimerType,
+		stats.Tags{"method": "put"})
+	service.metrics.putFromCacheDuration = stat.NewTaggedStat("keydb_grpc_cache_put_duration_seconds", stats.TimerType,
+		statsTags)
 
 	// Initialize caches for all hash ranges this node handles
 	if err := service.initCaches(ctx, false); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -178,7 +178,7 @@ func NewService(
 	}
 
 	var err error
-	service.cache, err = badger.New(service, kitConf, log.Child("badger"))
+	service.cache, err = badger.New(kitConf, log.Child("badger"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cache: %w", err)
 	}


### PR DESCRIPTION
# Description

- Add timers for get and put operations in the cache
- Add timers for key hashing in get and put operations
- Update Cache interface to include hashRange parameter in Get and Put methods
- Modify internal cache implementation to use the new hashRange parameter
- Update metrics configuration to include new timer stats
- Implement graceful shutdown of GRPC server
- Improve error logging and handling

## Linear Ticket

< Linear_Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
