### PR TITLE
chore: update Dockerfile references and image repository for keydb operator

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -194,6 +194,7 @@ jobs:
         uses: rudderlabs/build-scan-push-action@v1.5.3
         with:
           context: .
+          file: ./Dockerfile-operator
           platforms: ${{ matrix.build-config.platform }}
           push: true
           tags: ${{ matrix.build-config.tags }}

--- a/Makefile
+++ b/Makefile
@@ -100,13 +100,9 @@ deploy:
 		echo "Error: NAMESPACE variable is empty"; \
 		exit 1; \
 	fi
-	@if [ -z "$(DOCKER_USER)" ]; then \
-		echo "Error: DOCKER_USER variable is empty"; \
-		exit 1; \
-	fi
 	helm upgrade --install keydb-operator ./helm/keydb-operator \
 		--namespace $(NAMESPACE) \
-		--set image.repository=$(DOCKER_USER)/keydb-operator
+		--set image.repository=rudderstack/rudder-keydb-operator
 
 .PHONY: lint
 lint: fmt vulncheck ## Run linters on all go files

--- a/helm/keydb-operator/values.yaml
+++ b/helm/keydb-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: fracasula/keydb-operator
+  repository: rudderstack/rudder-keydb-operator
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
# Description

- fix docker image to use rudderlabs image
- add file name in build to build correct docker image

## Linear Ticket

< Linear_Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
