### PR TITLE
chore: adding download to hash range movements

### DIFF
--- a/cmd/operator/types.go
+++ b/cmd/operator/types.go
@@ -71,6 +71,7 @@ type HashRangeMovementsRequest struct {
 	NewClusterSize  uint32 `json:"newClusterSize"`
 	TotalHashRanges uint32 `json:"totalHashRanges"`
 	Upload          bool   `json:"upload,omitempty"`
+	Download        bool   `json:"download,omitempty"`
 	FullSync        bool   `json:"fullSync,omitempty"`
 }
 


### PR DESCRIPTION
# Description

Adding download to hash range movements for testing purposes or for forcing nodes to download data after a scaling has already happened.

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-2320/keydb-pre-download-in-hash-range-movements) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
