### PR TITLE
chore: retry policy

### DIFF
--- a/cmd/operator/server.go
+++ b/cmd/operator/server.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"golang.org/x/sync/errgroup"
@@ -16,6 +18,7 @@ import (
 	pb "github.com/rudderlabs/keydb/proto"
 	"github.com/rudderlabs/rudder-go-kit/jsonrs"
 	"github.com/rudderlabs/rudder-go-kit/logger"
+	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 )
 
 type operatorClient interface {
@@ -35,6 +38,7 @@ type httpServer struct {
 	client   *client.Client
 	operator operatorClient
 	server   *http.Server
+	logger   logger.Logger
 }
 
 // newHTTPServer creates a new HTTP server
@@ -42,6 +46,7 @@ func newHTTPServer(client *client.Client, operator *operator.Client, addr string
 	s := &httpServer{
 		client:   client,
 		operator: operator,
+		logger:   log,
 	}
 
 	mux := chi.NewRouter()
@@ -326,12 +331,14 @@ func (s *httpServer) handleAutoScale(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 	if newClusterSize > oldClusterSize {
-		err = s.handleScaleUp(r.Context(), req.OldNodesAddresses, req.NewNodesAddresses, req.FullSync)
+		err = s.handleScaleUp(r.Context(), req.OldNodesAddresses, req.NewNodesAddresses, req.FullSync, req.RetryPolicy)
 	} else if newClusterSize < oldClusterSize {
-		err = s.handleScaleDown(r.Context(), req.OldNodesAddresses, req.NewNodesAddresses, req.FullSync)
+		err = s.handleScaleDown(
+			r.Context(), req.OldNodesAddresses, req.NewNodesAddresses, req.FullSync, req.RetryPolicy,
+		)
 	} else {
 		// Auto-healing: propagate cluster addresses to all nodes for consistency
-		err = s.handleAutoHealing(r.Context(), req.OldNodesAddresses, req.NewNodesAddresses)
+		err = s.handleAutoHealing(r.Context(), req.OldNodesAddresses, req.NewNodesAddresses, req.RetryPolicy)
 	}
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error during auto scale operation: %v", err), http.StatusInternalServerError)
@@ -345,14 +352,24 @@ func (s *httpServer) handleAutoScale(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleScaleUp implements the scale up logic based on TestScaleUpAndDown
-func (s *httpServer) handleScaleUp(ctx context.Context, oldAddresses, newAddresses []string, fullSync bool) error {
+func (s *httpServer) handleScaleUp(
+	ctx context.Context, oldAddresses, newAddresses []string, fullSync bool, retryPolicy RetryPolicy,
+) error {
 	oldClusterSize := uint32(len(oldAddresses))
 	newClusterSize := uint32(len(newAddresses))
 
 	return s.operator.ExecuteScalingWithRollback(operator.ScaleUp, oldAddresses, newAddresses, func() error {
 		// Step 1: Update cluster data with new addresses
-		if err := s.operator.UpdateClusterData(newAddresses...); err != nil {
-			return fmt.Errorf("updating cluster data: %w", err)
+		err := s.retryViaPolicy(ctx, retryPolicy, func() error {
+			if err := s.operator.UpdateClusterData(newAddresses...); err != nil {
+				return fmt.Errorf("updating cluster data: %w", err)
+			}
+			return nil
+		}, "Cannot update cluster data",
+			logger.NewStringField("newAddresses", strings.Join(newAddresses, ",")),
+		)
+		if err != nil {
+			return err
 		}
 
 		// Step 2: Determine which hash ranges need to be moved and get ready-to-use maps
@@ -367,16 +384,21 @@ func (s *httpServer) handleScaleUp(ctx context.Context, oldAddresses, newAddress
 				continue
 			}
 			group.Go(func() error {
-				if err := s.operator.CreateSnapshots(gCtx, sourceNodeID, fullSync, hashRanges...); err != nil {
-					return fmt.Errorf("creating snapshots from node %d for hash ranges %v: %w",
-						sourceNodeID, hashRanges, err,
-					)
-				}
-				return nil
+				return s.retryViaPolicy(gCtx, retryPolicy, func() error {
+					err := s.operator.CreateSnapshots(gCtx, sourceNodeID, fullSync, hashRanges...)
+					if err != nil {
+						return fmt.Errorf("creating snapshots from node %d for hash ranges %v: %w",
+							sourceNodeID, hashRanges, err,
+						)
+					}
+					return nil
+				}, "Cannot create snapshots",
+					logger.NewIntField("nodeId", int64(sourceNodeID)),
+				)
 			})
 		}
 		if err := group.Wait(); err != nil {
-			return fmt.Errorf("waiting for snapshot creation: %w", err)
+			return err
 		}
 
 		// Step 4: Load snapshots to destination nodes
@@ -386,12 +408,16 @@ func (s *httpServer) handleScaleUp(ctx context.Context, oldAddresses, newAddress
 				continue
 			}
 			group.Go(func() error {
-				if err := s.operator.LoadSnapshots(gCtx, nodeID, hashRanges...); err != nil {
-					return fmt.Errorf("loading snapshots to node %d for hash ranges %v: %w",
-						nodeID, hashRanges, err,
-					)
-				}
-				return nil
+				return s.retryViaPolicy(gCtx, retryPolicy, func() error {
+					if err := s.operator.LoadSnapshots(gCtx, nodeID, hashRanges...); err != nil {
+						return fmt.Errorf("loading snapshots to node %d for hash ranges %v: %w",
+							nodeID, hashRanges, err,
+						)
+					}
+					return nil
+				}, "Cannot load snapshots",
+					logger.NewIntField("nodeId", int64(nodeID)),
+				)
 			})
 		}
 		if err := group.Wait(); err != nil {
@@ -399,12 +425,14 @@ func (s *httpServer) handleScaleUp(ctx context.Context, oldAddresses, newAddress
 		}
 
 		// Step 5: Scale all nodes
-		return s.completeScaleOperation(ctx, newClusterSize)
+		return s.completeScaleOperation(ctx, newClusterSize, retryPolicy)
 	})
 }
 
 // handleScaleDown implements the scale down logic based on TestScaleUpAndDown
-func (s *httpServer) handleScaleDown(ctx context.Context, oldAddresses, newAddresses []string, fullSync bool) error {
+func (s *httpServer) handleScaleDown(
+	ctx context.Context, oldAddresses, newAddresses []string, fullSync bool, retryPolicy RetryPolicy,
+) error {
 	oldClusterSize := uint32(len(oldAddresses))
 	newClusterSize := uint32(len(newAddresses))
 
@@ -420,12 +448,16 @@ func (s *httpServer) handleScaleDown(ctx context.Context, oldAddresses, newAddre
 				continue
 			}
 			group.Go(func() error {
-				if err := s.operator.CreateSnapshots(gCtx, sourceNodeID, fullSync, hashRanges...); err != nil {
-					return fmt.Errorf("creating snapshots from node %d for hash ranges %v: %w",
-						sourceNodeID, hashRanges, err,
-					)
-				}
-				return nil
+				return s.retryViaPolicy(gCtx, retryPolicy, func() error {
+					if err := s.operator.CreateSnapshots(gCtx, sourceNodeID, fullSync, hashRanges...); err != nil {
+						return fmt.Errorf("creating snapshots from node %d for hash ranges %v: %w",
+							sourceNodeID, hashRanges, err,
+						)
+					}
+					return nil
+				}, "Cannot create snapshots",
+					logger.NewIntField("nodeId", int64(sourceNodeID)),
+				)
 			})
 		}
 		if err := group.Wait(); err != nil {
@@ -439,12 +471,16 @@ func (s *httpServer) handleScaleDown(ctx context.Context, oldAddresses, newAddre
 				continue
 			}
 			group.Go(func() error {
-				if err := s.operator.LoadSnapshots(gCtx, nodeID, hashRanges...); err != nil {
-					return fmt.Errorf("loading snapshots to node %d for hash ranges %v: %w",
-						nodeID, hashRanges, err,
-					)
-				}
-				return nil
+				return s.retryViaPolicy(gCtx, retryPolicy, func() error {
+					if err := s.operator.LoadSnapshots(gCtx, nodeID, hashRanges...); err != nil {
+						return fmt.Errorf("loading snapshots to node %d for hash ranges %v: %w",
+							nodeID, hashRanges, err,
+						)
+					}
+					return nil
+				}, "Cannot load snapshots",
+					logger.NewIntField("nodeId", int64(nodeID)),
+				)
 			})
 		}
 		if err := group.Wait(); err != nil {
@@ -452,45 +488,108 @@ func (s *httpServer) handleScaleDown(ctx context.Context, oldAddresses, newAddre
 		}
 
 		// Step 3: Update cluster data with new addresses
-		if err := s.operator.UpdateClusterData(newAddresses...); err != nil {
-			return fmt.Errorf("updating cluster data: %w", err)
+		err := s.retryViaPolicy(ctx, retryPolicy, func() error {
+			if err := s.operator.UpdateClusterData(newAddresses...); err != nil {
+				return fmt.Errorf("updating cluster data: %w", err)
+			}
+			return nil
+		}, "Cannot update cluster data",
+			logger.NewStringField("newAddresses", strings.Join(newAddresses, ",")),
+		)
+		if err != nil {
+			return err
 		}
 
 		// Step 4: Scale remaining nodes
-		return s.completeScaleOperation(ctx, newClusterSize)
+		return s.completeScaleOperation(ctx, newClusterSize, retryPolicy)
 	})
 }
 
 // handleAutoHealing implements auto-healing by propagating cluster addresses to all nodes
 // This ensures all nodes have consistent cluster topology information
-func (s *httpServer) handleAutoHealing(ctx context.Context, oldAddresses, newAddresses []string) error {
+func (s *httpServer) handleAutoHealing(
+	ctx context.Context, oldAddresses, newAddresses []string, retryPolicy RetryPolicy,
+) error {
 	clusterSize := uint32(len(newAddresses))
 
 	return s.operator.ExecuteScalingWithRollback(operator.AutoHealing, oldAddresses, newAddresses, func() error {
 		// Step 1: Update cluster data with current addresses to ensure consistency
-		if err := s.operator.UpdateClusterData(newAddresses...); err != nil {
-			return fmt.Errorf("updating cluster data for auto-healing: %w", err)
+		err := s.retryViaPolicy(ctx, retryPolicy, func() error {
+			if err := s.operator.UpdateClusterData(newAddresses...); err != nil {
+				return fmt.Errorf("updating cluster data for auto-healing: %w", err)
+			}
+			return nil
+		}, "Cannot update cluster data",
+			logger.NewStringField("newAddresses", strings.Join(newAddresses, ",")),
+		)
+		if err != nil {
+			return err
 		}
 
 		// Step 2: Scale all nodes to refresh their cluster information
-		return s.completeScaleOperation(ctx, clusterSize)
+		return s.completeScaleOperation(ctx, clusterSize, retryPolicy)
 	})
 }
 
-func (s *httpServer) completeScaleOperation(ctx context.Context, clusterSize uint32) error {
+func (s *httpServer) completeScaleOperation(ctx context.Context, clusterSize uint32, rp RetryPolicy) error {
 	nodeIDs := make([]uint32, clusterSize)
 	for i := uint32(0); i < clusterSize; i++ {
 		nodeIDs[i] = i
 	}
-	if err := s.operator.Scale(ctx, nodeIDs); err != nil {
-		return fmt.Errorf("scaling nodes: %w", err)
+
+	err := s.retryViaPolicy(ctx, rp, func() error {
+		if err := s.operator.Scale(ctx, nodeIDs); err != nil {
+			return fmt.Errorf("scaling nodes: %w", err)
+		}
+		return nil
+	}, "Cannot scale",
+		logger.NewIntSliceField("nodeIds", nodeIDs),
+	)
+	if err != nil {
+		return err
 	}
 
-	if err := s.operator.ScaleComplete(ctx, nodeIDs); err != nil {
-		return fmt.Errorf("completing scale operation: %w", err)
+	err = s.retryViaPolicy(ctx, rp, func() error {
+		if err := s.operator.ScaleComplete(ctx, nodeIDs); err != nil {
+			return fmt.Errorf("completing scale operation: %w", err)
+		}
+		return nil
+	}, "Cannot complete scale operation",
+		logger.NewIntSliceField("nodeIds", nodeIDs),
+	)
+	if err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func (s *httpServer) retryViaPolicy(
+	ctx context.Context, retryPolicy RetryPolicy, fn func() error,
+	errorMessage string, loggerFields ...logger.Field,
+) error {
+	if retryPolicy.MaxInterval == 0 {
+		return fn() // retries are disabled
+	}
+
+	bo := backoff.NewExponentialBackOff()
+	bo.Multiplier = retryPolicy.Multiplier
+	bo.InitialInterval = retryPolicy.InitialInterval
+	bo.MaxInterval = retryPolicy.MaxInterval
+	operation := func() (string, error) {
+		return "", fn()
+	}
+
+	_, err := backoff.Retry(ctx, operation,
+		backoff.WithBackOff(bo),
+		backoff.WithNotify(func(err error, duration time.Duration) {
+			s.logger.Warnn(errorMessage, append(loggerFields,
+				logger.NewDurationField("duration", duration),
+				obskit.Error(err),
+			)...)
+		}),
+	)
+	return err
 }
 
 // handleHashRangeMovements handles POST /hashRangeMovements requests

--- a/cmd/operator/server_test.go
+++ b/cmd/operator/server_test.go
@@ -271,8 +271,11 @@ func TestAutoScale(t *testing.T) {
 		Keys: []string{"key1", "key2", "key3", "key4", "key5", "key6", "key7", "key8"},
 	})
 	require.JSONEq(t,
-		`{"key1":true,"key2":true,"key3":true,"key4":false,"key5":true,"key6":true,"key7":true,"key8":true}`, body,
+		`{"key1":true,"key2":true,"key3":true,"key4":false,"key5":true,"key6":true,"key7":true,"key8":true}`,
+		body,
 	)
+
+	t.Log("Scaling down from 2 nodes to 1 node...")
 
 	// Test Scale Down using autoScale
 	_ = op.Do("/autoScale", AutoScaleRequest{
@@ -804,7 +807,9 @@ func getService(
 
 	log := logger.NOP
 	if testing.Verbose() {
-		log = logger.NewLogger()
+		lf := logger.NewFactory(conf)
+		require.NoError(t, lf.SetLogLevel("", "DEBUG"))
+		log = lf.NewLogger()
 	}
 	conf.Set("BadgerDB.Dedup.NopLogger", true)
 	service, err := node.NewService(ctx, nodeConfig, cs, conf, stats.NOP, log)

--- a/cmd/operator/types.go
+++ b/cmd/operator/types.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/rudderlabs/keydb/internal/operator"
+import (
+	"time"
+
+	"github.com/rudderlabs/keydb/internal/operator"
+)
 
 // GetRequest represents a request to get keys
 type GetRequest struct {
@@ -64,7 +68,14 @@ type AutoScaleRequest struct {
 	NewNodesAddresses []string `json:"new_nodes_addresses"`
 	// FullSync indicates whether to perform a full synchronization during snapshot creation.
 	// When true, all data will be included in snapshots regardless of incremental changes.
-	FullSync bool `json:"full_sync,omitempty"`
+	FullSync    bool        `json:"full_sync,omitempty"`
+	RetryPolicy RetryPolicy `json:"retry_policy,omitempty"`
+}
+
+type RetryPolicy struct {
+	InitialInterval time.Duration `json:"initial_interval"`
+	Multiplier      float64       `json:"multiplier"`
+	MaxInterval     time.Duration `json:"max_interval"`
 }
 
 // HashRangeMovementsRequest represents a request to preview hash range movements

--- a/cmd/operator/types.go
+++ b/cmd/operator/types.go
@@ -76,6 +76,7 @@ type RetryPolicy struct {
 	InitialInterval time.Duration `json:"initial_interval"`
 	Multiplier      float64       `json:"multiplier"`
 	MaxInterval     time.Duration `json:"max_interval"`
+	MaxElapsedTime  time.Duration `json:"max_elapsed_time"`
 }
 
 // HashRangeMovementsRequest represents a request to preview hash range movements

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 require (
 	github.com/DataDog/zstd v1.5.7
 	github.com/aws/aws-sdk-go v1.55.7
+	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/dgraph-io/badger/v4 v4.7.0
 	github.com/dgraph-io/ristretto/v2 v2.2.0
 	github.com/go-chi/chi/v5 v5.2.2
@@ -58,7 +59,6 @@ require (
 	github.com/aws/smithy-go v1.22.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect


### PR DESCRIPTION
# Description

Retry policy for auto-scaling operations.

### Behaviour before these changes
* Network errors led to retries thanks to the gRPC client automatic retries

### Behaviour after these changes
* Along with network retries, now also unrelated errors are retried e.g. S3 timeouts when dealing with snapshots

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-2324/keydb-operator-to-retry-before-rolling-back) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
