### PR TITLE
feat: add configurable backup folder name and refactor snapshot file path

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -116,6 +116,7 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 		),
 		Addresses:                 strings.Split(nodeAddresses, ","),
 		LogTableStructureDuration: conf.GetDuration("logTableStructureDuration", 10, time.Minute),
+		BackupFolderName:          conf.GetString("KUBE_NAMESPACE", ""),
 	}
 
 	port := conf.GetInt("port", 50051)


### PR DESCRIPTION
# Description

- Add BackupFolderName configuration option to NodeConfig
- Refactor getSnapshotFilenamePrefix to use BackupFolderName
- Update snapshot file path generation to include backup folder name

## Linear Ticket

pipe-2318

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
