### PR TITLE
fix: handle context cancellation in snapshot creation

### DIFF
--- a/internal/cache/badger/badger.go
+++ b/internal/cache/badger/badger.go
@@ -234,7 +234,10 @@ func (c *Cache) CreateSnapshots(
 	defer func() {
 		for _, lw := range lockedWriters {
 			if lw.closer != nil {
+				// this prevents race conditions with Badger's background goroutines
+				lw.mu.Lock()
 				_ = lw.closer.Close()
+				lw.mu.Unlock()
 			}
 		}
 	}()


### PR DESCRIPTION
# Description

- Prevent race conditions with Badger's background goroutines when closing writers
- Add unit test for context cancellation in snapshot creation

## Linear Ticket

pipe-2319

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
