### PR TITLE
chore: load snapshots max concurrency

### DIFF
--- a/cmd/node/config.go
+++ b/cmd/node/config.go
@@ -34,4 +34,12 @@ var customBuckets = map[string][]float64{
 		// 10microsecond, 25microsecond, 50microsecond, 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s
 		0.00001, 0.00025, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
 	},
+	"keydb_download_snapshot_duration_seconds": {
+		// 1ms, 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 20s, 30s, 60s
+		0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60,
+	},
+	"keydb_load_snapshot_duration_seconds": {
+		// 1ms, 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 20s, 30s, 60s
+		0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60,
+	},
 }


### PR DESCRIPTION
# Description

Making concurrency right + metrics for monitoring the download and the load parts.

## Linear Ticket

< [Linear_Link](https://linear.app/rudderstack/issue/PIPE-2342/keydb-fix-load-snapshots-max-concurrency) >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
