### PR TITLE
chore: update release-please action to use googleapis namespace

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,7 +12,7 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.PAT }}
           target-branch: ${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
# Description

replace deprecated `google-github-actions/release-please-action` with `googleapis/release-please-action`

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
