### PR TITLE
feat: add gRPC health check service for readiness/liveness probes

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -18,6 +19,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/rudderlabs/keydb/internal/cloudstorage"
@@ -25,6 +28,7 @@ import (
 	pb "github.com/rudderlabs/keydb/proto"
 	"github.com/rudderlabs/keydb/release"
 	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/filemanager"
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	_ "github.com/rudderlabs/rudder-go-kit/maxprocs"
 	"github.com/rudderlabs/rudder-go-kit/profiler"
@@ -48,6 +52,16 @@ const (
 
 type keyDBResponse interface {
 	GetSuccess() bool
+}
+
+// cloudStorage is the subset of *filemanager.S3Manager that node.NewService
+// needs. Declared here (instead of importing node's unexported interface) so
+// runWith is testable with fakes — this is the only reason it's an interface.
+type cloudStorage interface {
+	Download(ctx context.Context, output io.WriterAt, key string, opts ...filemanager.DownloadOption) error
+	ListFilesWithPrefix(ctx context.Context, startAfter, prefix string, maxItems int64) filemanager.ListSession
+	UploadReader(ctx context.Context, objName string, rdr io.Reader) (filemanager.UploadedFile, error)
+	Delete(ctx context.Context, keys []string) error
 }
 
 func main() {
@@ -89,7 +103,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(ctx, cancel, conf, stat, log); err != nil {
+	storage, err := cloudstorage.GetCloudStorage(conf, log)
+	if err != nil {
+		log.Errorn("Failed to initialize cloud storage", obskit.Error(err))
+		os.Exit(1)
+	}
+
+	if err := run(ctx, cancel, conf, stat, log, storage); err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.Errorn("Failed to run", obskit.Error(err))
 			os.Exit(1)
@@ -98,15 +118,9 @@ func main() {
 	}
 }
 
-func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Stats, log logger.Logger) error {
-	defer log.Infon("Service terminated")
-	defer cancel()
-
-	cloudStorage, err := cloudstorage.GetCloudStorage(conf, log)
-	if err != nil {
-		return fmt.Errorf("failed to create cloud storage: %w", err)
-	}
-
+func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Stats,
+	log logger.Logger, storage cloudStorage,
+) error {
 	podName := conf.GetStringVar("", "nodeId")
 	nodeID, err := getNodeID(podName)
 	if err != nil {
@@ -159,8 +173,10 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 	}
 
 	port := conf.GetIntVar(50051, 1, "port")
+	healthPort := conf.GetIntVar(50052, 1, "healthPort")
 	log = log.Withn(
 		logger.NewIntField("port", int64(port)),
+		logger.NewIntField("healthPort", int64(healthPort)),
 		logger.NewIntField("nodeId", nodeConfig.NodeID),
 		logger.NewIntField("totalHashRanges", nodeConfig.TotalHashRanges),
 	)
@@ -171,17 +187,6 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 		logger.NewIntField("noOfAddresses", int64(len(addresses))),
 		logger.NewStringField("nodeAddresses", strings.Join(addresses, ",")),
 	)
-
-	service, err := node.NewService(ctx, nodeConfig, cloudStorage, conf, stat, log.Child("service"))
-	if err != nil {
-		return fmt.Errorf("failed to create node service: %w", err)
-	}
-
-	degradedNodesObserver := &configObserver{
-		key: degradedNodesConfKey,
-		f:   service.DegradedNodesChanged,
-	}
-	conf.RegisterObserver(degradedNodesObserver)
 
 	var wg sync.WaitGroup
 	defer func() {
@@ -204,6 +209,46 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 			return
 		}
 	}()
+
+	// Start a lightweight health-only gRPC server BEFORE the slow node.NewService init.
+	// This way Kubernetes liveness/readiness probes have something to talk to from the
+	// first moment the process starts listening, and the pod isn't killed during a slow
+	// startup (e.g. snapshot download, cache warmup, etc.).
+	//
+	//   - Overall health ("") = SERVING immediately       -> liveness passes
+	//   - "keydb.NodeService"  = NOT_SERVING until ready   -> readiness gates traffic
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pb.NodeService_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+
+	healthGrpcServer := grpc.NewServer()
+	healthpb.RegisterHealthServer(healthGrpcServer, healthServer)
+
+	healthLis, err := net.Listen("tcp", fmt.Sprintf(":%d", healthPort))
+	if err != nil {
+		return fmt.Errorf("listening on health port %d: %w", healthPort, err)
+	}
+
+	healthErrCh := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		log.Infon("Starting health gRPC server")
+		if err := healthGrpcServer.Serve(healthLis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			healthErrCh <- fmt.Errorf("health server error: %w", err)
+		}
+	}()
+
+	service, err := node.NewService(ctx, nodeConfig, storage, conf, stat, log.Child("service"))
+	if err != nil {
+		return fmt.Errorf("creating node service: %w", err)
+	}
+
+	degradedNodesObserver := &configObserver{
+		key: degradedNodesConfKey,
+		f:   service.DegradedNodesChanged,
+	}
+	conf.RegisterObserver(degradedNodesObserver)
 
 	// Configure gRPC server keepalive parameters
 	grpcKeepaliveMinTime := conf.GetDurationVar(10, time.Second, "grpc.keepalive.minTime")
@@ -252,11 +297,14 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 	)
 
 	pb.RegisterNodeServiceServer(server, service)
+	// Also expose the health service on the main port so in-cluster clients that dial
+	// 50051 can use gRPC health checks without a round-trip to the health port.
+	healthpb.RegisterHealthServer(server, healthServer)
 
 	// Start listening
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
-		return fmt.Errorf("failed to listen: %w", err)
+		return fmt.Errorf("listening on port %d: %w", port, err)
 	}
 
 	log.Infon("Starting node service server",
@@ -288,16 +336,29 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 		defer wg.Done()
 		<-ctx.Done()
 		log.Infon("Terminating service")
+		// Flip health status to NOT_SERVING first so readiness probes fail and
+		// Kubernetes removes this pod from Service endpoints before we stop serving.
+		healthServer.Shutdown()
 		service.Close()
 		server.GracefulStop()
 		_ = lis.Close()
+		// Stop the dedicated health server last so probes can still be answered
+		// (with NOT_SERVING) while the main server is draining.
+		healthGrpcServer.GracefulStop()
+		_ = healthLis.Close()
 	}()
+
+	// Main server is now serving -> mark NodeService ready so readiness probes
+	// pass and Kubernetes starts routing traffic to this pod.
+	healthServer.SetServingStatus(pb.NodeService_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
 
 	select {
 	case <-ctx.Done():
 		log.Infon("Shutting down HTTP server")
 		return ctx.Err()
 	case err := <-serverErrCh:
+		return err
+	case err := <-healthErrCh:
 		return err
 	}
 }

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -65,7 +65,12 @@ type cloudStorage interface {
 }
 
 func main() {
+	os.Exit(runNode())
+}
+
+func runNode() int {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill, syscall.SIGTERM)
+	defer cancel()
 
 	conf := config.New(config.WithEnvPrefix("KEYDB"))
 	logFactory := logger.NewFactory(conf)
@@ -100,22 +105,22 @@ func main() {
 
 	if err := stat.Start(ctx, stats.DefaultGoRoutineFactory); err != nil {
 		log.Errorn("Failed to start Stats", obskit.Error(err))
-		os.Exit(1)
+		return 1
 	}
 
 	storage, err := cloudstorage.GetCloudStorage(conf, log)
 	if err != nil {
 		log.Errorn("Failed to initialize cloud storage", obskit.Error(err))
-		os.Exit(1)
+		return 1
 	}
 
 	if err := run(ctx, cancel, conf, stat, log, storage); err != nil {
 		if !errors.Is(err, context.Canceled) {
 			log.Errorn("Failed to run", obskit.Error(err))
-			os.Exit(1)
+			return 1
 		}
-		os.Exit(0)
 	}
+	return 0
 }
 
 func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Stats,
@@ -230,14 +235,12 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 	}
 
 	healthErrCh := make(chan error, 1)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		log.Infon("Starting health gRPC server")
 		if err := healthGrpcServer.Serve(healthLis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			healthErrCh <- fmt.Errorf("health server error: %w", err)
 		}
-	}()
+	})
 
 	service, err := node.NewService(ctx, nodeConfig, storage, conf, stat, log.Child("service"))
 	if err != nil {
@@ -312,28 +315,22 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 		logger.NewStringField("degradedNodes", degradedNodes.Load()),
 	)
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer log.Infon("Profiler server terminated")
 		if err := profiler.StartServer(ctx, conf.GetIntVar(7777, 1, "Profiler.Port")); err != nil {
 			log.Warnn("Profiler server failed", obskit.Error(err))
 			return
 		}
-	}()
+	})
 
 	serverErrCh := make(chan error, 1)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		if err := server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErrCh <- fmt.Errorf("server error: %w", err)
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-ctx.Done()
 		log.Infon("Terminating service")
 		// Flip health status to NOT_SERVING first so readiness probes fail and
@@ -346,7 +343,7 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 		// (with NOT_SERVING) while the main server is draining.
 		healthGrpcServer.GracefulStop()
 		_ = healthLis.Close()
-	}()
+	})
 
 	// Main server is now serving -> mark NodeService ready so readiness probes
 	// pass and Kubernetes starts routing traffic to this pod.
@@ -354,7 +351,7 @@ func run(ctx context.Context, cancel func(), conf *config.Config, stat stats.Sta
 
 	select {
 	case <-ctx.Done():
-		log.Infon("Shutting down HTTP server")
+		log.Infon("Shutting down GRPC server")
 		return ctx.Err()
 	case err := <-serverErrCh:
 		return err

--- a/cmd/node/main_test.go
+++ b/cmd/node/main_test.go
@@ -1,7 +1,22 @@
 package main
 
 import (
+	"context"
+	"net"
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	pb "github.com/rudderlabs/keydb/proto"
+	"github.com/rudderlabs/rudder-go-kit/config"
+	"github.com/rudderlabs/rudder-go-kit/logger"
+	"github.com/rudderlabs/rudder-go-kit/stats"
+	"github.com/rudderlabs/rudder-go-kit/testhelper"
 )
 
 func TestGetNodeID(t *testing.T) {
@@ -122,4 +137,146 @@ func TestGetNodeID(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunWith_HealthEndpoints boots the full runWith() — exactly the code path
+// the binary runs in production — against a fake cloud storage and asserts:
+//   - the health endpoint is reachable on healthPort
+//   - liveness ("") is SERVING (pod won't be killed during startup)
+//   - readiness ("keydb.NodeService") becomes SERVING once NodeService is registered
+//   - the main gRPC port also serves the health service
+//   - SIGTERM / context cancel flips everything to NOT_SERVING and shuts down cleanly
+func TestRunWith_HealthEndpoints(t *testing.T) {
+	mainPort, err := testhelper.GetFreePort()
+	require.NoError(t, err)
+	healthPort, err := testhelper.GetFreePort()
+	require.NoError(t, err)
+	profilerPort, err := testhelper.GetFreePort()
+	require.NoError(t, err)
+
+	conf := config.New()
+	conf.Set("port", mainPort)
+	conf.Set("healthPort", healthPort)
+	conf.Set("Profiler.Port", profilerPort)
+	conf.Set("nodeId", "keydb-1-0")
+	conf.Set("nodeAddresses", "localhost:"+strconv.Itoa(mainPort)+",localhost:"+strconv.Itoa(mainPort))
+	conf.Set("BadgerDB.Dedup.Path", t.TempDir())
+	conf.Set("shutdownTimeout", "5s")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Run the binary's real entry point (minus cloudStorage construction) in a
+	// goroutine. runErrCh receives the terminal error so the test can assert
+	// clean shutdown at the end.
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- run(ctx, cancel, conf, stats.NOP, logger.NOP, &mockedCloudStorage{})
+	}()
+
+	healthAddr := "localhost:" + strconv.Itoa(healthPort)
+	mainAddr := "localhost:" + strconv.Itoa(mainPort)
+
+	newHealthClient := func(t *testing.T, addr string) healthpb.HealthClient {
+		t.Helper()
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = conn.Close() })
+		return healthpb.NewHealthClient(conn)
+	}
+
+	checkStatus := func(t *testing.T, client healthpb.HealthClient, service string) (
+		healthpb.HealthCheckResponse_ServingStatus, error,
+	) {
+		t.Helper()
+		reqCtx, reqCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer reqCancel()
+		resp, err := client.Check(reqCtx, &healthpb.HealthCheckRequest{Service: service})
+		if err != nil {
+			return 0, err
+		}
+		return resp.Status, nil
+	}
+
+	healthClient := newHealthClient(t, healthAddr)
+
+	// Step 1: the health port must come up before NodeService is ready. Because
+	// NodeService init is effectively instant with the mocked cloud storage,
+	// we can't *observe* NOT_SERVING reliably here we assert the contract
+	// that SetServingStatus/Shutdown code paths were wired up by reaching
+	// SERVING on both endpoints quickly.
+	require.Eventually(t, func() bool {
+		s, err := checkStatus(t, healthClient, "")
+		return err == nil && s == healthpb.HealthCheckResponse_SERVING
+	}, 10*time.Second, 50*time.Millisecond, "liveness ('') must be SERVING on health port")
+
+	t.Run("readiness on health port reports NodeService SERVING once ready", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			s, err := checkStatus(t, healthClient, pb.NodeService_ServiceDesc.ServiceName)
+			return err == nil && s == healthpb.HealthCheckResponse_SERVING
+		}, 10*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("main gRPC port also serves the health service", func(t *testing.T) {
+		// The main server registers health alongside NodeService, so clients
+		// dialing 50051 can use gRPC health checks without a second connection.
+		mainClient := newHealthClient(t, mainAddr)
+		require.Eventually(t, func() bool {
+			s, err := checkStatus(t, mainClient, pb.NodeService_ServiceDesc.ServiceName)
+			return err == nil && s == healthpb.HealthCheckResponse_SERVING
+		}, 10*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("NodeService RPC succeeds once readiness is SERVING", func(t *testing.T) {
+		// Sanity check: if readiness says SERVING, an actual RPC should work.
+		// Otherwise the health signal is lying and k8s would route traffic to a
+		// broken pod.
+		conn, err := grpc.NewClient(mainAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = conn.Close() })
+
+		reqCtx, reqCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer reqCancel()
+		resp, err := pb.NewNodeServiceClient(conn).GetNodeInfo(reqCtx, &pb.GetNodeInfoRequest{})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), resp.NodeId)
+	})
+
+	// Step 2: simulate SIGTERM via context cancel. The shutdown handler must
+	// flip everything to NOT_SERVING *before* the health server stops, so
+	// readiness probes drain endpoints cleanly rather than hit a closed port.
+	t.Run("shutdown flips readiness to NOT_SERVING before closing", func(t *testing.T) {
+		cancel()
+
+		// We might observe NOT_SERVING, or the connection might close. Both are
+		// acceptable shutdown signals (k8s treats either as probe failure). The
+		// crucial property is: we never see SERVING after shutdown started.
+		require.Eventually(t, func() bool {
+			s, err := checkStatus(t, healthClient, pb.NodeService_ServiceDesc.ServiceName)
+			if err != nil {
+				return true
+			}
+			return s == healthpb.HealthCheckResponse_NOT_SERVING
+		}, 10*time.Second, 50*time.Millisecond)
+	})
+
+	t.Run("run returns cleanly", func(t *testing.T) {
+		select {
+		case err := <-runErrCh:
+			// context.Canceled is the expected terminal error when ctx is cancelled.
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(10 * time.Second):
+			t.Fatal("run did not return within shutdown timeout")
+		}
+	})
+
+	// Ports must actually be released after shutdown — otherwise subsequent
+	// test runs (or the next binary start) would fail to bind.
+	t.Run("ports are released after shutdown", func(t *testing.T) {
+		for _, addr := range []string{healthAddr, mainAddr} {
+			lis, err := net.Listen("tcp", addr)
+			require.NoErrorf(t, err, "port %s should be released after shutdown", addr)
+			_ = lis.Close()
+		}
+	})
 }


### PR DESCRIPTION
# Description

Expose the standard **gRPC Health Checking Protocol** (`grpc.health.v1.Health`) from KeyDB so Kubernetes can reliably probe pod readiness and liveness and avoid the failure mode where clients see `connection refused` against a pod that is starting, dead, or draining.

 ## Problem                                                                                                                                                                                              
                                                            
 Today keydb's gRPC server only starts *after* `node.NewService` finishes (opens badger, initializes hash-range caches). During that window, the pod answers nothing on any 
port. K8s has no signal to distinguish "still starting" from "crashed," and any client that dials the headless service hits raw `TRANSIENT_FAILURE` / `connection refused`.
                                                                                                                                                                                                          
  Observed in prod:                                         
  ```
dns:///keydb-0-0.keydb-headless.xxx.svc.cluster.local:50051
  connState: TRANSIENT_FAILURE                                                                                                                                                                            
  error: connection error: dial tcp x.x.x.x:50051: connect: connection refused
```
                                                                                                                                                                                                          
  ## Solution                                                                                                                                                                                             
                                                                                                                                                                                                          
  Two gRPC servers sharing one `*health.Server`:                                                                                                                                                          
                                                            
  1. **Dedicated health-only server** on `healthPort` (default `50052`, env `KEYDB_HEALTH_PORT`) starts *immediately*, before `node.NewService`. Answers `grpc.health.v1.Health/Check` from moment one.   
  2. **Main server** on `port` (default `50051`) registers `NodeService` + `Health` and starts serving once node init completes.
                                                                                                                                                                                                          
  Health states are driven by lifecycle:                                                                                                                                                                  
                                                                                                                                                                                                          
  | Phase                         | `""` (liveness)  | `keydb.NodeService` (readiness) |                                                                                                                  
  | ----------------------------- | ---------------- | ------------------------------- |
  | Process starts                | **SERVING**      | NOT_SERVING                     |                                                                                                                  
  | `node.NewService` in progress | **SERVING**      | NOT_SERVING                     |
  | Main server serving           | **SERVING**      | **SERVING**                     |                                                                                                                  
  | SIGTERM received              | **NOT_SERVING**  | **NOT_SERVING**                 |                                                                                                                  
                                                                                                                                                                                                          
  Net effect:                                                                                                                                                                                             
  - **Startup**: liveness passes in ms, pod isn't killed during cold starts / snapshot loads. Readiness stays red → no traffic routed to a warming-up pod.
  - **Running**: both green.                                                                                                                                                                              
  - **Shutdown**: readiness goes red *before* the main server stops → K8s drains endpoints cleanly instead of clients getting `connection refused`. Dedicated health server stops *last* so probes get
  `NOT_SERVING` (a useful signal) rather than `connection refused` "ambiguous" throughout the drain.                                                                                                      
                                                            
  ## Changes                                                                                                                                                                                              
                                                            
  ### `cmd/node/main.go`                                                                                                                                                                                  
  - Register `google.golang.org/grpc/health` on both servers.
  - New `healthPort` config (default `50052`, env `KEYDB_HEALTH_PORT`).                                                                                                                                   
  - Shutdown order: `healthServer.Shutdown()` → `service.Close()` → main `GracefulStop` → dedicated health `GracefulStop`.                                                                                
  - Also expose health on the main port so in-cluster clients can use `grpc.health.v1.Health` without a second connection.                                                                                
  - **Refactor**: extracted cloud-storage construction from `run()` into `main()` so `run` accepts a `cloudStorage` interface (dependency injection) which enables testing without S3/AWS credentials.        
  Production path unchanged; `*filemanager.S3Manager` still satisfies the interface.

## Linear Ticket

pipe-2901

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
