### PR TITLE
chore: bump build-scan-push-action from v2.1.0 to v2.2.0

### DIFF
--- a/.github/workflows/docker-build-ecr.yml
+++ b/.github/workflows/docker-build-ecr.yml
@@ -139,7 +139,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build, scan and push
-        uses: rudderlabs/build-scan-push-action@96d7bfca912dd2e8805dbb322dc2540504ecac1e # v2.1.0
+        uses: rudderlabs/build-scan-push-action@865b4253caa57f8f20cd109e0efc1affe3a64939 # v2.2.0
         with:
           context: .
           file: ./${{ inputs.dockerfile }}


### PR DESCRIPTION
## Summary
- Update `rudderlabs/build-scan-push-action` from `v2.1.0` to `v2.2.0`
- SHA: `96d7bfca912dd2e8805dbb322dc2540504ecac1e` → `865b4253caa57f8f20cd109e0efc1affe3a64939`

## Files changed
- \`.github/workflows/docker-build-ecr.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)